### PR TITLE
ci: #34 Update github workflow actions and pin them to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: true
@@ -28,4 +28,3 @@ jobs:
 
       - name: Run build.sh
         run: ./build.sh
-

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install tools
         run: |

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code

--- a/.github/workflows/google-tests.yml
+++ b/.github/workflows/google-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   google-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code

--- a/.github/workflows/google-tests.yml
+++ b/.github/workflows/google-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Checkout submodules
         run: git submodule update --init --recursive


### PR DESCRIPTION
Close #34
Update actions/checkout from v3 to v7.0.1.

Pin all checkout references to the immutable commit SHA while retaining the release tag in comments for maintainability.

| Repository                        |  Tag     |  Commit SHA                              |  Commit creation date   |
|-----------------------------------|----------|------------------------------------------|-------------------------|
| actions/checkout                  | v7.0.1   | 3d3c42e5aac5ba805825da76410c181273ba90b1 | 2026-07-17 18:45:11 UTC |
